### PR TITLE
Expand tests, update README, support repeated flags.

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,22 +12,29 @@ options.
 
 (import argparse :prefix "")
 
-(def res
-  (argparse
-    "A simple CLI tool. An example to start showing the capabilities of argparse."
-    "verbose" {:kind :flag
-               :short "v"
-               :help "Print debug information to stdout."}
-    "key" {:kind :option
-           :short "k"
-           :help "An API key for getting stuff from a server."
-           :required true}
-    "thing" {:kind :option
-             :help "Some option?"
-             :default "123"}))
+(def argparse-params
+  ["A simple CLI tool. An example to show the capabilities of argparse."
+   "debug" {:kind :flag
+            :short "d"
+            :help "Set debug mode."}
+   "verbose" {:kind :multi
+              :short "v"
+              :help "Print debug information to stdout."}
+   "key" {:kind :option
+          :short "k"
+          :help "An API key for getting stuff from a server."
+          :required true}
+   "expr" {:kind :accumulate
+           :short "e"
+           :help "Search for all patterns given."}
+   "thing" {:kind :option
+            :help "Some option?"
+            :default "123"}])
 
-(unless res (os/exit 1))
-(pp res)
+(let [res (argparse ;argparse-params)]
+  (unless res
+    (os/exit 1))
+  (pp res))
 ```
 
 ## Installing

--- a/argparse.janet
+++ b/argparse.janet
@@ -23,10 +23,11 @@
 
   The keys in each option table are as follows:\n\n
 
-  \t:kind - What kind of option is this? One of :flag, :option, or :accumulate.
-  A flag can either be on or off, an option is a key that will be set in the returned
-  table, and accumulate means an option can be specified 0 or more times, each
-  time appending a value to an array.\n
+  \t:kind - What kind of option is this? One of :flag, :multi, :option, or
+  :accumulate. A flag can either be on or off, a multi is a flag that can be provided
+  multiple times, each time adding 1 to a returned integer, an option is a key that
+  will be set in the returned table, and accumulate means an option can be specified
+  0 or more times, each time appending a value to an array.\n
   \t:short - Single letter for shorthand access.\n
   \t:help - Help text for the option, explaining what it is.\n
   \t:default - Default value for the option.\n
@@ -116,6 +117,10 @@
     [name handler]
     (case (handler :kind)
       :flag (put res name true)
+      :multi (do
+               (var count (or (get res name) 0))
+               (++ count)
+               (put res name count))
       :option (do
                 (put res name (get args i))
                 (++ i))

--- a/test/test1.janet
+++ b/test/test1.janet
@@ -13,10 +13,10 @@
             :help "Some option?"
             :default "123"}])
 
-(with-dyns [:args @["janet" "somescript.janet" "-k" "100"]]
+(with-dyns [:args @["somescript.janet" "-k" "100"]]
   (def res (argparse ;argparse-params))
   (unless (= (res "key") "100") (error "bad key"))
   (unless (= (res "thing") "123") (error "bad thing")))
 
-(with-dyns [:args @["janet" "somescript.janet" "-h"]]
+(with-dyns [:args @["somescript.janet" "-h"]]
   (def res (argparse ;argparse-params)))

--- a/test/test1.janet
+++ b/test/test1.janet
@@ -13,10 +13,11 @@
             :help "Some option?"
             :default "123"}])
 
-(with-dyns [:args @["somescript.janet" "-k" "100"]]
+(with-dyns [:args @["testcase.janet" "-k" "100"]]
   (def res (argparse ;argparse-params))
-  (unless (= (res "key") "100") (error "bad key"))
-  (unless (= (res "thing") "123") (error "bad thing")))
+  (unless (= (res "key") "100") (error (string "bad key: " (res "key"))))
+  (unless (= (res "thing") "123") (error (string "bad thing: " (res "thing")))))
 
-(with-dyns [:args @["somescript.janet" "-h"]]
+(with-dyns [:args @["testcase.janet" "-h"]]
+  (print "test -h flag (help output below is a passing test) ...")
   (def res (argparse ;argparse-params)))

--- a/test/test1.janet
+++ b/test/test1.janet
@@ -2,7 +2,10 @@
 
 (def argparse-params
   ["A simple CLI tool. An example to start showing the capabilities of argparse."
-   "verbose" {:kind :flag
+   "debug" {:kind :flag
+            :short "d"
+            :help "Set debug mode."}
+   "verbose" {:kind :multi
               :short "v"
               :help "Print debug information to stdout."}
    "key" {:kind :option
@@ -18,16 +21,18 @@
 
 (with-dyns [:args @["testcase.janet" "-k" "100"]]
   (def res (argparse ;argparse-params))
+  (when (res "debug") (error (string "bad debug: " (res "debug"))))
   (when (res "verbose") (error (string "bad verbose: " (res "verbose"))))
   (unless (= (res "key") "100") (error (string "bad key: " (res "key"))))
   (when (res "expr")
     (error (string "bad expr: " (string/join (res "expr") " "))))
   (unless (= (res "thing") "123") (error (string "bad thing: " (res "thing")))))
 
-(with-dyns [:args @["testcase.janet" "-k" "100" "-v" "--thing" "456"
-                    "-e" "abc" "-e" "def"]]
+(with-dyns [:args @["testcase.janet" "-k" "100" "-v" "--thing" "456" "-d" "-v"
+                    "-e" "abc" "-vvv" "-e" "def"]]
   (def res (argparse ;argparse-params))
-  (unless (res "verbose") (error (string "bad verbose: " (res "verbose"))))
+  (unless (res "debug") (error (string "bad debug: " (res "debug"))))
+  (unless (= (res "verbose") 5) (error (string "bad verbose: " (res "verbose"))))
   (unless (= (tuple ;(res "expr")) ["abc" "def"])
     (error (string "bad expr: " (string/join (res "expr") " "))))
   (unless (= (res "thing") "456") (error (string "bad thing: " (res "thing")))))

--- a/test/test1.janet
+++ b/test/test1.janet
@@ -1,7 +1,7 @@
 (import ../argparse :prefix "")
 
 (def argparse-params
-  ["A simple CLI tool. An example to start showing the capabilities of argparse."
+  ["A simple CLI tool. An example to show the capabilities of argparse."
    "debug" {:kind :flag
             :short "d"
             :help "Set debug mode."}

--- a/test/test1.janet
+++ b/test/test1.janet
@@ -15,8 +15,14 @@
 
 (with-dyns [:args @["testcase.janet" "-k" "100"]]
   (def res (argparse ;argparse-params))
+  (when (res "verbose") (error (string "bad verbose: " (res "verbose"))))
   (unless (= (res "key") "100") (error (string "bad key: " (res "key"))))
   (unless (= (res "thing") "123") (error (string "bad thing: " (res "thing")))))
+
+(with-dyns [:args @["testcase.janet" "-k" "100" "-v" "--thing" "456"]]
+  (def res (argparse ;argparse-params))
+  (unless (res "verbose") (error (string "bad verbose: " (res "verbose"))))
+  (unless (= (res "thing") "456") (error (string "bad thing: " (res "thing")))))
 
 (with-dyns [:args @["testcase.janet" "-h"]]
   (print "test -h flag (help output below is a passing test) ...")

--- a/test/test1.janet
+++ b/test/test1.janet
@@ -9,6 +9,9 @@
           :short "k"
           :help "An API key for getting stuff from a server."
           :required true}
+   "expr" {:kind :accumulate
+           :short "e"
+           :help "Search for all patterns given."}
    "thing" {:kind :option
             :help "Some option?"
             :default "123"}])
@@ -17,11 +20,16 @@
   (def res (argparse ;argparse-params))
   (when (res "verbose") (error (string "bad verbose: " (res "verbose"))))
   (unless (= (res "key") "100") (error (string "bad key: " (res "key"))))
+  (when (res "expr")
+    (error (string "bad expr: " (string/join (res "expr") " "))))
   (unless (= (res "thing") "123") (error (string "bad thing: " (res "thing")))))
 
-(with-dyns [:args @["testcase.janet" "-k" "100" "-v" "--thing" "456"]]
+(with-dyns [:args @["testcase.janet" "-k" "100" "-v" "--thing" "456"
+                    "-e" "abc" "-e" "def"]]
   (def res (argparse ;argparse-params))
   (unless (res "verbose") (error (string "bad verbose: " (res "verbose"))))
+  (unless (= (tuple ;(res "expr")) ["abc" "def"])
+    (error (string "bad expr: " (string/join (res "expr") " "))))
   (unless (= (res "thing") "456") (error (string "bad thing: " (res "thing")))))
 
 (with-dyns [:args @["testcase.janet" "-h"]]


### PR DESCRIPTION
Hello! These commits cover a few topics, but do flow together. Let's discuss.

* Add a new `:kind` to support repeated flags; instead of a boolean, get an integer count. This is a Unix-y thing to specify: more `-v` for more verbosity; repeat `-l` for less secure (e.g. `sfill` does this). I was looking around for a canonical Unix-like name for this type of option flag, to inform the name of the `:kind` keyword. I landed on `:multi` by intuition in seeing what the project already has ("it's a multi flag"). Otherwise, here's what I see elsewhere, which doesn't help name a keyword:
  * Python's argparse has "nargs" to specify zero or one (`?`), zero or more (`*`), and one or more (`+`) much like glob and regular expressions.
  * Others specify a type or similar such validator, in which a sequence type specifies repeatable flags.
* Update the README to match the idiomatic move to `(dyn :args)`, which leads to the next question ...
* What minimum version of Janet should this argparse project support?

I'm testing on Janet 1.3.0-37a943d.