### PR TITLE
Fix catching :default option

### DIFF
--- a/argparse.janet
+++ b/argparse.janet
@@ -169,7 +169,7 @@
 
       # default
       (if-let [handler (options :default)]
-        (do (++ i) (handle-option :default handler))
+        (handle-option :default handler)
         (usage "could not handle option " arg))))
 
   # Handle defaults, required options

--- a/test/test1.janet
+++ b/test/test1.janet
@@ -2,6 +2,7 @@
 
 (def argparse-params
   ["A simple CLI tool. An example to show the capabilities of argparse."
+   :default {:kind :option}
    "debug" {:kind :flag
             :short "d"
             :help "Set debug mode."}
@@ -40,3 +41,10 @@
 (with-dyns [:args @["testcase.janet" "-h"]]
   (print "test -h flag (help output below is a passing test) ...")
   (def res (argparse ;argparse-params)))
+
+(with-dyns [:args @["testcase.janet" "server"]]
+  (def res (argparse 
+             "A simple CLI tool. An example to show the capabilities of argparse."
+             :default {:kind :option}))
+  (unless (= (res :default) "server")
+    (error (string "bad default " (res :default)))))

--- a/test/test1.janet
+++ b/test/test1.janet
@@ -2,7 +2,6 @@
 
 (def argparse-params
   ["A simple CLI tool. An example to show the capabilities of argparse."
-   :default {:kind :option}
    "debug" {:kind :flag
             :short "d"
             :help "Set debug mode."}

--- a/test/test1.janet
+++ b/test/test1.janet
@@ -44,7 +44,14 @@
 
 (with-dyns [:args @["testcase.janet" "server"]]
   (def res (argparse 
-             "A simple CLI tool. An example to show the capabilities of argparse."
+             "A simple CLI tool."
              :default {:kind :option}))
   (unless (= (res :default) "server")
+    (error (string "bad default " (res :default)))))
+
+(with-dyns [:args @["testcase.janet" "server" "run"]]
+  (def res (argparse 
+             "A simple CLI tool."
+             :default {:kind :accumulate}))
+  (unless (and (deep= (res :default) @["server" "run"]))
     (error (string "bad default " (res :default)))))


### PR DESCRIPTION
Hello, the current behaviour is confusing for me. As for catching the `:default` you have to have two options, and parser ignores the first one.