### PR TITLE
Treat unset arguments as errors.

### DIFF
--- a/argparse.janet
+++ b/argparse.janet
@@ -121,14 +121,18 @@
                (var count (or (get res name) 0))
                (++ count)
                (put res name count))
-      :option (do
-                (put res name (get args i))
-                (++ i))
-      :accumulate (do
-                    (def arr (or (get res name) @[]))
-                    (array/push arr (get args i))
-                    (++ i)
-                    (put res name arr))
+      :option (if-let [arg (get args i)]
+                (do
+                  (put res name arg)
+                  (++ i))
+                (usage "missing argument for " name))
+      :accumulate (if-let [arg (get args i)]
+                    (do
+                      (def arr (or (get res name) @[]))
+                      (array/push arr arg)
+                      (++ i)
+                      (put res name arr))
+                    (usage "missing argument for " name))
       # default
       (usage "unknown option kind: " (handler :kind)))
 

--- a/test/test1.janet
+++ b/test/test1.janet
@@ -19,6 +19,10 @@
             :help "Some option?"
             :default "123"}])
 
+(defmacro suppress-stdout [& body]
+  ~(with-dyns [:out (file/open (if (os/stat "/dev/null") "/dev/null" "nul"))]
+     ,;body))
+
 (with-dyns [:args @["testcase.janet" "-k" "100"]]
   (def res (argparse ;argparse-params))
   (when (res "debug") (error (string "bad debug: " (res "debug"))))
@@ -29,11 +33,11 @@
   (unless (= (res "thing") "123") (error (string "bad thing: " (res "thing")))))
 
 (with-dyns [:args @["testcase.janet" "-k" "100" "--thing"]]
-  (def res (argparse ;argparse-params))
+  (def res (suppress-stdout (argparse ;argparse-params)))
   (when res (error "Option \"thing\" missing arg, but result is non-nil.")))
 
 (with-dyns [:args @["testcase.janet" "-k" "100" "-e" "foo" "-e"]]
-  (def res (argparse ;argparse-params))
+  (def res (suppress-stdout (argparse ;argparse-params)))
   (when res (error "Option \"expr\" missing arg, but result is non-nil.")))
 
 (with-dyns [:args @["testcase.janet" "-k" "100" "-v" "--thing" "456" "-d" "-v"
@@ -64,6 +68,5 @@
     (error (string "bad default " (res :default)))))
 
 (with-dyns [:args @["testcase.janet" "-k" "100" "--fake"]]
-  (print "test unknown flag (help output below is a passing test) ...")
-  (def res (argparse ;argparse-params))
+  (def res (suppress-stdout (argparse ;argparse-params)))
   (when res (error "Option \"fake\" is not valid, but result is non-nil.")))

--- a/test/test1.janet
+++ b/test/test1.janet
@@ -28,6 +28,14 @@
     (error (string "bad expr: " (string/join (res "expr") " "))))
   (unless (= (res "thing") "123") (error (string "bad thing: " (res "thing")))))
 
+(with-dyns [:args @["testcase.janet" "-k" "100" "--thing"]]
+  (def res (argparse ;argparse-params))
+  (when res (error "Option \"thing\" missing arg, but result is non-nil.")))
+
+(with-dyns [:args @["testcase.janet" "-k" "100" "-e" "foo" "-e"]]
+  (def res (argparse ;argparse-params))
+  (when res (error "Option \"expr\" missing arg, but result is non-nil.")))
+
 (with-dyns [:args @["testcase.janet" "-k" "100" "-v" "--thing" "456" "-d" "-v"
                     "-e" "abc" "-vvv" "-e" "def"]]
   (def res (argparse ;argparse-params))

--- a/test/test1.janet
+++ b/test/test1.janet
@@ -54,3 +54,8 @@
              :default {:kind :accumulate}))
   (unless (and (deep= (res :default) @["server" "run"]))
     (error (string "bad default " (res :default)))))
+
+(with-dyns [:args @["testcase.janet" "-k" "100" "--fake"]]
+  (print "test unknown flag (help output below is a passing test) ...")
+  (def res (argparse ;argparse-params))
+  (when res (error "Option \"fake\" is not valid, but result is non-nil.")))

--- a/test/test1.janet
+++ b/test/test1.janet
@@ -42,14 +42,14 @@
   (def res (argparse ;argparse-params)))
 
 (with-dyns [:args @["testcase.janet" "server"]]
-  (def res (argparse 
+  (def res (argparse
              "A simple CLI tool."
              :default {:kind :option}))
   (unless (= (res :default) "server")
     (error (string "bad default " (res :default)))))
 
 (with-dyns [:args @["testcase.janet" "server" "run"]]
-  (def res (argparse 
+  (def res (argparse
              "A simple CLI tool."
              :default {:kind :accumulate}))
   (unless (and (deep= (res :default) @["server" "run"]))


### PR DESCRIPTION
For `:accumulate` and `:option`, the argument parser should error out if there's no follow-on argument. Before this patch:

```bash
janet main.janet -o # -o is :option without :default => @{}
janet main.janet -a # -a is :accumulate => @{"option-name" @[nil]}
```

After this patch, argparse produces usage statements and returns nil in those cases.