### PR TITLE
Track order of arguments as metadata.

### DIFF
--- a/argparse.janet
+++ b/argparse.janet
@@ -60,7 +60,7 @@
       (put shortcodes (code 0) {:name k :handler v})))
 
   # Results table and other things
-  (def res @{})
+  (def res @{:order @[]})
   (def args (dyn :args))
   (def arglen (length args))
   (var scanning true)
@@ -115,6 +115,7 @@
   # Handle an option
   (defn handle-option
     [name handler]
+    (array/push (res :order) name)
     (case (handler :kind)
       :flag (put res name true)
       :multi (do

--- a/test/test1.janet
+++ b/test/test1.janet
@@ -47,7 +47,11 @@
   (unless (= (res "verbose") 5) (error (string "bad verbose: " (res "verbose"))))
   (unless (= (tuple ;(res "expr")) ["abc" "def"])
     (error (string "bad expr: " (string/join (res "expr") " "))))
-  (unless (= (res "thing") "456") (error (string "bad thing: " (res "thing")))))
+  (unless (= (res "thing") "456") (error (string "bad thing: " (res "thing"))))
+  (unless (= (tuple ;(res :order))
+             ["key" "verbose" "thing" "debug" "verbose"
+              "expr" "verbose" "verbose" "verbose" "expr"])
+    (error (string "bad order: " (string/join (res :order) " ")))))
 
 (with-dyns [:args @["testcase.janet" "-h"]]
   (print "help output below")


### PR DESCRIPTION
Allow projects to inspect the order of arguments without re-parsing.

Use case: A project takes input from a variety of sources, specified via two or more `:accumulate` options, and order matters.

[Real world example of this use case](https://github.com/rduplain/hosts/blob/73a022407ee2a0ff651c882e0094d432c8049bb2/hosts.janet#L173).

The name of `:order` metadata warrants review. A keyword (e.g. `:order`) is safe for metadata as long as argparse continues to expect string keys in the input options table. Would additional metadata lead to `:meta @{:order @[]}` being more sensible? Probably not. Just use more keywords for future metadata.