### PR TITLE
Treat every argument after -- as unnamed arguments

### DIFF
--- a/argparse.janet
+++ b/argparse.janet
@@ -39,6 +39,8 @@
   that do not start with a -- or -. Use this option to collect unnamed
   arguments to your script.\n\n
 
+  After `--`, every argument is treated as an unnamed argument.\n\n
+
   Once parsed, values are accessible in the returned table by the name
   of the option. For example (result \"verbose\") will check if the verbose
   flag is enabled."
@@ -66,6 +68,7 @@
   (var scanning true)
   (var bad false)
   (var i 1)
+  (var process-options? true)
 
   # Show usage
   (defn usage
@@ -152,9 +155,15 @@
   (while (and scanning (< i arglen))
     (def arg (get args i))
     (cond
+      # `--` turns off option processing so that
+      # the rest of arguments are treated like unnamed arguments.
+      (and (= "--" arg) process-options?)
+      (do
+        (set process-options? false)
+        (++ i))
 
       # long name (--name)
-      (string/has-prefix? "--" arg)
+      (and (string/has-prefix? "--" arg) process-options?)
       (let [name (string/slice arg 2)
             handler (get options name)]
         (++ i)
@@ -163,7 +172,7 @@
           (usage "unknown option " name)))
 
       # short names (-flags)
-      (string/has-prefix? "-" arg)
+      (and (string/has-prefix? "-" arg) process-options?)
       (let [flags (string/slice arg 1)]
         (++ i)
         (each flag flags

--- a/test/test1.janet
+++ b/test/test1.janet
@@ -74,3 +74,17 @@
 (with-dyns [:args @["testcase.janet" "-k" "100" "--fake"]]
   (def res (suppress-stdout (argparse ;argparse-params)))
   (when res (error "Option \"fake\" is not valid, but result is non-nil.")))
+
+(with-dyns [:args @["testcase.janet" "-l" "100" "--" "echo" "-n" "ok"]]
+  (if-let [{"length" len :default cmd-args}
+           (suppress-stdout (argparse "A simple CLI tool"
+                                      "length" {:kind :option
+                                                :short "l"
+                                                :help "key"}
+                                      :default {:kind :accumulate}))]
+    (do
+      (unless (= len "100")
+        (error "option was not parsed correctly in the presence of `--`."))
+      (unless (= ["echo" "-n" "ok"] (tuple ;cmd-args))
+        (error "unnamed arguments after `--` were not parsed correctly.")))
+    (error "arguments were not parsed correctly in the presence of `--`.")))


### PR DESCRIPTION
If argparse treated every argument after -- as unnamed arguments, we can collect raw command arguments and pass them to other programs.