### PR TITLE
Check usage message against expected string

### DIFF
--- a/test/test1.janet
+++ b/test/test1.janet
@@ -53,9 +53,24 @@
               "expr" "verbose" "verbose" "verbose" "expr"])
     (error (string "bad order: " (string/join (res :order) " ")))))
 
-(with-dyns [:args @["testcase.janet" "-h"]]
-  (print "help output below")
-  (def res (argparse ;argparse-params)))
+(let [out @""]
+  (with-dyns [:args @["testcase.janet" "-h"]
+              :out  out]
+    (def res (argparse ;argparse-params))
+    (when res (error "Option \"h\", but result is non-nil."))
+    (def msg
+      (string "usage: testcase.janet [option] ... \n\n"
+              "A simple CLI tool. An example to show the capabilities of argparse.\n\n"
+              " Required:\n"
+              " -k, --key VALUE                             An API key for getting stuff from a server.\n\n"
+              " Optional:\n"
+              " -d, --debug                                 Set debug mode.\n"
+              " -e, --expr VALUE                            Search for all patterns given.\n"
+              " -h, --help                                  Show this help message.\n"
+              "     --thing VALUE=123                       Some option?\n"
+              " -v, --verbose                               Print debug information to stdout.\n\n"))
+    (unless (not (= (string out) msg))
+      (error (string "bad usage message:\n\n" out)))))
 
 (with-dyns [:args @["testcase.janet" "server"]]
   (def res (suppress-stdout (argparse


### PR DESCRIPTION
The test suite currently prints the usage message as one of the tests but this message isn't checked against any expected output. This PR changes that test to capture the output in a buffer and then check it against an expected message.