### PR TITLE
Add brief usage instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,20 @@ will install the latest from master.
 
 ## Usage
 
+Call `argparse/argparse` to attempt to parse the command line args
+(available at `(dyn :args)`).
+
+The first argument should be a description to be displayed as help
+text.
+
+All subsequent options should be alternating keys and values where the
+keys are options to accept and the values are definitions of each option.
+
+To accept positional arguments, include a definition for the special
+value `:default`. For instance, to gather all positional arguments
+into an array, include `:default {:kind :accumulate}` in your
+arguments to `argparse`.
+
 Run `(doc argparse/argparse)` after importing for more information.
 
 ## License


### PR DESCRIPTION
The first (couple of) time I used argparse, I had trouble seeing how to handle "normal" positional arguments. This just includes a simple usage blurb in the README.